### PR TITLE
Add LAPPD pulse half height timing and half end timing to tree

### DIFF
--- a/DataModel/LAPPDPulse.h
+++ b/DataModel/LAPPDPulse.h
@@ -22,12 +22,20 @@ class LAPPDPulse : public Hit{
 	inline void SetChannelID(int channelid){ChannelID=channelid;}
 	inline void SetPeak(double peak){Peak=peak;}
 	inline void SetRange(double low, double hi){LowRange=low; HiRange=hi;}
+	inline void SetHalfHeightTime(double half){halfHeightTime=half;}
+	inline double GetHalfHeightTime(){return halfHeightTime;}
+	inline void SetHalfEndTime(double half){halfEndTime=half;}
+	inline double GetHalfEndTime(){return halfEndTime;}
+	inline void SetBaseline(double base){baseline=base;}
+	inline double GetBaseline(){return baseline;}
 
 	bool Print() {
 		cout<<"TubeId : "<<TubeId<<endl;
 		cout<<"ChannelID : "<<ChannelID<<endl;
 		cout<<"Time : "<<Time<<endl;
 		cout<<"Charge : "<<Charge<<endl;
+		cout<<"HalfHeightTime : "<<halfHeightTime<<endl;
+		cout<<"Baseline : "<<baseline<<endl;
 		return true;
 	}
 
@@ -36,6 +44,10 @@ class LAPPDPulse : public Hit{
 	double Peak;
 	double LowRange;
 	double HiRange;
+	double halfHeightTime;
+	double halfEndTime;
+	double baseline;
+
 
 
 	template<class Archive> void serialize(Archive & ar, const unsigned int version){
@@ -47,6 +59,9 @@ class LAPPDPulse : public Hit{
 			ar & Peak;
 			ar & LowRange;
 			ar & HiRange;
+			ar & halfHeightTime;
+			ar & halfEndTime;
+			ar & baseline;
 		}
 	}
 };

--- a/UserTools/ANNIEEventTreeMaker/ANNIEEventTreeMaker.cpp
+++ b/UserTools/ANNIEEventTreeMaker/ANNIEEventTreeMaker.cpp
@@ -181,16 +181,19 @@ bool ANNIEEventTreeMaker::Initialise(std::string configfile, DataModel &data)
     fANNIETree->Branch("LAPPD_TSCorrection", &fLAPPD_TSCorrection);
     fANNIETree->Branch("LAPPD_BGCorrection", &fLAPPD_BGCorrection);
     fANNIETree->Branch("LAPPD_OSInMinusPS", &fLAPPD_OSInMinusPS);
-    if(LAPPD_PPS_fill){
-    fANNIETree->Branch("LAPPD_BGPPSBefore", &fLAPPD_BGPPSBefore);
-    fANNIETree->Branch("LAPPD_BGPPSAfter", &fLAPPD_BGPPSAfter);
-    fANNIETree->Branch("LAPPD_BGPPSDiff", &fLAPPD_BGPPSDiff);
-    fANNIETree->Branch("LAPPD_BGPPSMissing", &fLAPPD_BGPPSMissing);
-    fANNIETree->Branch("LAPPD_TSPPSBefore", &fLAPPD_TSPPSBefore);
-    fANNIETree->Branch("LAPPD_TSPPSAfter", &fLAPPD_TSPPSAfter);
-    fANNIETree->Branch("LAPPD_TSPPSDiff", &fLAPPD_TSPPSDiff);
-    fANNIETree->Branch("LAPPD_TSPPSMissing", &fLAPPD_TSPPSMissing);
+    if (LAPPD_PPS_fill)
+    {
+      fANNIETree->Branch("LAPPD_BGPPSBefore", &fLAPPD_BGPPSBefore);
+      fANNIETree->Branch("LAPPD_BGPPSAfter", &fLAPPD_BGPPSAfter);
+      fANNIETree->Branch("LAPPD_BGPPSDiff", &fLAPPD_BGPPSDiff);
+      fANNIETree->Branch("LAPPD_BGPPSMissing", &fLAPPD_BGPPSMissing);
+      fANNIETree->Branch("LAPPD_TSPPSBefore", &fLAPPD_TSPPSBefore);
+      fANNIETree->Branch("LAPPD_TSPPSAfter", &fLAPPD_TSPPSAfter);
+      fANNIETree->Branch("LAPPD_TSPPSDiff", &fLAPPD_TSPPSDiff);
+      fANNIETree->Branch("LAPPD_TSPPSMissing", &fLAPPD_TSPPSMissing);
     }
+    fANNIETree->Branch("LAPPD_BG_switchBit0", &fLAPPD_BG_switchBit0);
+    fANNIETree->Branch("LAPPD_BG_switchBit1", &fLAPPD_BG_switchBit1);
   }
 
   // LAPPD reconstruction information
@@ -205,6 +208,7 @@ bool ANNIEEventTreeMaker::Initialise(std::string configfile, DataModel &data)
     fANNIETree->Branch("LAPPD_PulseIDs", &fLAPPD_IDs);
     fANNIETree->Branch("LAPPD_ChannelID", &fChannelID);
     fANNIETree->Branch("LAPPD_PeakTime", &fPulsePeakTime);
+    fANNIETree->Branch("LAPPD_PulseHalfHeightTime", &fPulseHalfHeightTime);
     fANNIETree->Branch("LAPPD_PeakAmp", &fPulsePeakAmp);
     fANNIETree->Branch("LAPPD_Charge", &fPulseCharge);
     fANNIETree->Branch("LAPPD_PulseStart", &fPulseStart);
@@ -232,6 +236,10 @@ bool ANNIEEventTreeMaker::Initialise(std::string configfile, DataModel &data)
     fANNIETree->Branch("LAPPDHitP2PeakTime", &fLAPPDHitP2PeakTime);
     fANNIETree->Branch("LAPPDHitP1PeakAmp", &fLAPPDHitP1PeakAmp);
     fANNIETree->Branch("LAPPDHitP2PeakAmp", &fLAPPDHitP2PeakAmp);
+    fANNIETree->Branch("LAPPDHitP1HalfHeightTime", &fLAPPDHitP1HalfHeightTime);
+    fANNIETree->Branch("LAPPDHitP2HalfHeightTime", &fLAPPDHitP2HalfHeightTime);
+    fANNIETree->Branch("LAPPDHitP1HalfEndTime", &fLAPPDHitP1HalfEndTime);
+    fANNIETree->Branch("LAPPDHitP2HalfEndTime", &fLAPPDHitP2HalfEndTime);
 
     /*
     fANNIETree->Branch("LAPPDWaveformChankey", &LAPPDWaveformChankey, "LAPPDWaveformChankey/I");
@@ -633,6 +641,8 @@ void ANNIEEventTreeMaker::ResetVariables()
   fLAPPD_TSCorrection.clear();
   fLAPPD_BGCorrection.clear();
   fLAPPD_OSInMinusPS.clear();
+  fLAPPD_BG_switchBit0.clear();
+  fLAPPD_BG_switchBit1.clear();
   // LAPPD_PPS_fill
   fLAPPD_BGPPSBefore.clear();
   fLAPPD_BGPPSAfter.clear();
@@ -649,6 +659,7 @@ void ANNIEEventTreeMaker::ResetVariables()
   fLAPPD_IDs.clear();
   fChannelID.clear();
   fPulsePeakTime.clear();
+  fPulseHalfHeightTime.clear();
   fPulseCharge.clear();
   fPulsePeakAmp.clear();
   fPulseStart.clear();
@@ -675,6 +686,10 @@ void ANNIEEventTreeMaker::ResetVariables()
   fLAPPDHitP2PeakTime.clear();
   fLAPPDHitP1PeakAmp.clear();
   fLAPPDHitP2PeakAmp.clear();
+  fLAPPDHitP1HalfHeightTime.clear();
+  fLAPPDHitP2HalfHeightTime.clear();
+  fLAPPDHitP1HalfEndTime.clear();
+  fLAPPDHitP2HalfEndTime.clear();
 
   LAPPDWaveformChankey.clear();
   waveformMaxValue.clear();
@@ -900,6 +915,7 @@ void ANNIEEventTreeMaker::ResetVariables()
   LAPPDTSCorrection.clear();
   LAPPDBGCorrection.clear();
   LAPPDOSInMinusPS.clear();
+  SwitchBitBG.clear();
   // LAPPD_PPS_fill
   LAPPDBG_PPSBefore.clear();
   LAPPDBG_PPSAfter.clear();
@@ -927,7 +943,15 @@ bool ANNIEEventTreeMaker::LoadEventInfo()
   m_data->Stores["ANNIEEvent"]->Get("RunNumber", fRunNumber);
   m_data->Stores["ANNIEEvent"]->Get("SubRunNumber", fSubrunNumber);
   m_data->Stores["ANNIEEvent"]->Get("PartNumber", fPartFileNumber);
-  m_data->Stores["ANNIEEvent"]->Get("EventNumber", fEventNumber);
+  bool gotEventNumber = m_data->Stores["ANNIEEvent"]->Get("EventNumber", fEventNumber);
+  if (!gotEventNumber)
+  {
+    uint32_t enm = 9998;
+    m_data->CStore.Get("EventNumberTree", enm);
+    cout << "ANNIEEventTreeMaker Tool: Not get the event number from ANNIEEvent, get from CStore: " << enm << endl;
+    fEventNumber = static_cast<int>(enm);
+  }
+
   m_data->Stores["ANNIEEvent"]->Get("PrimaryTriggerWord", fPrimaryTriggerWord);
   if (fPrimaryTriggerWord == 14)
     trigword = 5;
@@ -1226,6 +1250,7 @@ void ANNIEEventTreeMaker::LoadLAPPDInfo()
   m_data->Stores["ANNIEEvent"]->Get("LAPPDTS_PPSAfter", LAPPDTS_PPSAfter);
   m_data->Stores["ANNIEEvent"]->Get("LAPPDTS_PPSDiff", LAPPDTS_PPSDiff);
   m_data->Stores["ANNIEEvent"]->Get("LAPPDTS_PPSMissing", LAPPDTS_PPSMissing);
+  m_data->Stores["ANNIEEvent"]->Get("SwitchBitBG", SwitchBitBG);
 
   if (LAPPDDataMap.size() != 0)
   {
@@ -1264,6 +1289,18 @@ void ANNIEEventTreeMaker::FillLAPPDInfo()
     fLAPPD_TSPPSAfter.push_back(LAPPDTS_PPSAfter[key]);
     fLAPPD_TSPPSDiff.push_back(LAPPDTS_PPSDiff[key]);
     fLAPPD_TSPPSMissing.push_back(LAPPDTS_PPSMissing[key]);
+    // check if SwitchBitBG has the key
+    if (SwitchBitBG.find(psecData.LAPPD_ID) != SwitchBitBG.end())
+    {
+      if(SwitchBitBG[psecData.LAPPD_ID].size() != 2)
+      {
+        cout<<"ANNIEEventTreeMaker: SwitchBitBG size is not 2, LAPPD_ID: "<<psecData.LAPPD_ID<<", size: "<<SwitchBitBG[psecData.LAPPD_ID].size()<<endl;
+        continue;
+      }
+      fLAPPD_BG_switchBit0.push_back(SwitchBitBG[psecData.LAPPD_ID][0]);
+      fLAPPD_BG_switchBit1.push_back(SwitchBitBG[psecData.LAPPD_ID][1]);
+      continue;
+    }
   }
 }
 
@@ -1289,6 +1326,7 @@ void ANNIEEventTreeMaker::FillLAPPDPulse()
         fChannelID.push_back(thisPulse.GetChannelID());
         fPulseStripNum.push_back(stripno);
         fPulsePeakTime.push_back(thisPulse.GetTime());
+        fPulseHalfHeightTime.push_back(thisPulse.GetHalfHeightTime());
         fPulseCharge.push_back(thisPulse.GetCharge());
         fPulsePeakAmp.push_back(thisPulse.GetPeak());
         fPulseStart.push_back(thisPulse.GetLowRange());
@@ -1303,6 +1341,7 @@ void ANNIEEventTreeMaker::FillLAPPDPulse()
         fChannelID.push_back(thisPulse.GetChannelID());
         fPulseStripNum.push_back(stripno);
         fPulsePeakTime.push_back(thisPulse.GetTime());
+        fPulseHalfHeightTime.push_back(thisPulse.GetHalfHeightTime());
         fPulseCharge.push_back(thisPulse.GetCharge());
         fPulsePeakAmp.push_back(thisPulse.GetPeak());
         fPulseStart.push_back(thisPulse.GetLowRange());
@@ -1345,7 +1384,7 @@ void ANNIEEventTreeMaker::FillLAPPDHit()
         // fLAPPDHitP2StartTime.push_back(thisHit.GetPulse2StartTime());
         // fLAPPDHitP1EndTime.push_back(thisHit.GetPulse1LastTime());
         // fLAPPDHitP2EndTime.push_back(thisHit.GetPulse2LastTime());
-        //cout<<"Pulse 1 start time: "<<p1.GetLowRange()<<", Pulse 2 start time: "<<p2.GetLowRange()<<endl;
+        // cout<<"Pulse 1 start time: "<<p1.GetLowRange()<<", Pulse 2 start time: "<<p2.GetLowRange()<<endl;
         fLAPPDHitP1StartTime.push_back(p1.GetLowRange());
         fLAPPDHitP2StartTime.push_back(p2.GetLowRange());
         fLAPPDHitP1EndTime.push_back(p1.GetHiRange());
@@ -1355,6 +1394,12 @@ void ANNIEEventTreeMaker::FillLAPPDHit()
         fLAPPDHitP2PeakTime.push_back(p2.GetTime());
         fLAPPDHitP1PeakAmp.push_back(p1.GetPeak());
         fLAPPDHitP2PeakAmp.push_back(p2.GetPeak());
+
+        fLAPPDHitP1HalfHeightTime.push_back(p1.GetHalfHeightTime());
+        fLAPPDHitP2HalfHeightTime.push_back(p2.GetHalfHeightTime());
+
+        fLAPPDHitP1HalfEndTime.push_back(p1.GetHalfEndTime());
+        fLAPPDHitP2HalfEndTime.push_back(p2.GetHalfEndTime());
       }
     }
   }

--- a/UserTools/ANNIEEventTreeMaker/ANNIEEventTreeMaker.h
+++ b/UserTools/ANNIEEventTreeMaker/ANNIEEventTreeMaker.h
@@ -221,6 +221,8 @@ private:
     vector<uint64_t> fLAPPD_TSPPSAfter;
     vector<uint64_t> fLAPPD_TSPPSDiff;
     vector<int> fLAPPD_TSPPSMissing;
+    vector<int> fLAPPD_BG_switchBit0;
+    vector<int> fLAPPD_BG_switchBit1;
 
     // LAPPD Reco Fill
     vector<uint64_t> fLAPPDPulseTimeStampUL;
@@ -228,6 +230,7 @@ private:
     vector<int> fLAPPD_IDs;
     vector<int> fChannelID;
     vector<double> fPulsePeakTime;
+    vector<double> fPulseHalfHeightTime;
     vector<double> fPulseCharge;
     vector<double> fPulsePeakAmp;
     vector<double> fPulseStart;
@@ -254,6 +257,10 @@ private:
     vector<double> fLAPPDHitP2PeakTime;
     vector<double> fLAPPDHitP1PeakAmp;
     vector<double> fLAPPDHitP2PeakAmp;
+    vector<double> fLAPPDHitP1HalfHeightTime;
+    vector<double> fLAPPDHitP2HalfHeightTime;
+    vector<double> fLAPPDHitP1HalfEndTime;
+    vector<double> fLAPPDHitP2HalfEndTime;
 
     // waveform
     vector<int> LAPPDWaveformChankey;
@@ -499,6 +506,7 @@ private:
     std::map<uint64_t, uint64_t> LAPPDTS_PPSAfter;
     std::map<uint64_t, uint64_t> LAPPDTS_PPSDiff;
     std::map<uint64_t, int> LAPPDTS_PPSMissing;
+    std::map<int, vector<int>> SwitchBitBG; 
 
     std::map<unsigned long, vector<vector<LAPPDPulse>>> lappdPulses;
     std::map<unsigned long, vector<LAPPDHit>> lappdHits;

--- a/UserTools/LAPPDLoadStore/LAPPDLoadStore.h
+++ b/UserTools/LAPPDLoadStore/LAPPDLoadStore.h
@@ -64,6 +64,7 @@ private:
     bool MultiLAPPDMap; // loading map of multiple LAPPDs from ANNIEEvent
     bool loadOffsets;
     bool LoadBuiltPPSInfo;
+    bool loadFromStoreDirectly;
     // Variables that you need in the tool
     int retval; // track the data parsing and meta parsing status
     int eventNo;

--- a/UserTools/LoadANNIEEvent/LoadANNIEEvent.cpp
+++ b/UserTools/LoadANNIEEvent/LoadANNIEEvent.cpp
@@ -293,7 +293,9 @@ bool LoadANNIEEvent::Execute() {
  
 
 
-  if (global_evnr && !has_local){ m_data->Stores["ANNIEEvent"]->Set("EventNumber",global_ev); }
+  if (global_evnr && !has_local){ m_data->Stores["ANNIEEvent"]->Set("EventNumber",global_ev); 
+  m_data->CStore.Set("EventNumberTree",global_ev);
+  }
   global_ev++; 
 
   if ( current_entry_ >= total_entries_in_file_ ) {

--- a/configfiles/BeamClusterAnalysis/ToolsConfig
+++ b/configfiles/BeamClusterAnalysis/ToolsConfig
@@ -1,7 +1,5 @@
 myLoadANNIEEvent LoadANNIEEvent ./configfiles/BeamClusterAnalysis/LoadANNIEEventConfig
 myLoadGeometry LoadGeometry ./configfiles/LoadGeometry/LoadGeometryConfig
-#myPhaseIIADCCalibrator PhaseIIADCCalibrator ./configfiles/BeamClusterAnalysis/PhaseIIADCCalibratorConfig
-#myPhaseIIADCHitFinder PhaseIIADCHitFinder ./configfiles/BeamClusterAnalysis/PhaseIIADCHitFinderConfig
 myTimeClustering TimeClustering configfiles/BeamClusterAnalysis/TimeClusteringConfig
 myFindMrdTracks FindMrdTracks configfiles/BeamClusterAnalysis/FindMrdTracksConfig
 myClusterFinder ClusterFinder ./configfiles/BeamClusterAnalysis/ClusterFinderConfig
@@ -17,4 +15,3 @@ LAPPDThresReco LAPPDThresReco configfiles/LAPPDProcessedAna/ConfigPlot
 FitRWMWaveform FitRWMWaveform ./configfiles/BeamClusterAnalysis/FitRWMWaveformConfig
 
 ANNIEEventTreeMaker ANNIEEventTreeMaker ./configfiles/BeamClusterAnalysis/ANNIEEventTreeMakerConfig
-#myPhaseIITreeMaker PhaseIITreeMaker ./configfiles/BeamClusterAnalysis/PhaseIITreeMakerConfig

--- a/configfiles/LAPPDProcessedAna/ConfigStoreReadIn
+++ b/configfiles/LAPPDProcessedAna/ConfigStoreReadIn
@@ -28,7 +28,6 @@ Pedinputfile2 ../Pedestals/PEDS_ACDC_board1.txt
 
 #LAPPDReorderData
 LAPPDReorderVerbosityLevel 0
-ReorderVerbosityLevel 0
 ReorderInputWavLabel RawLAPPDData
 ReorderOutputWavLabel LAPPDWaveforms
 DelayOffset 0

--- a/configfiles/LAPPDProcessedAna/Configs
+++ b/configfiles/LAPPDProcessedAna/Configs
@@ -24,6 +24,8 @@ Nboards 6 #Number of pedestal files to be read in
 PedinputfileTXT ../Pedestals/LAPPD645839/P
 PSECinputfile /pnfs/annie/persistent/processed/LAPPD40Merged/FinalVersion_withRawTS/FilteredData_PMT_MRDtrack_noveto_15mV_7strips_3xxx_104
 
+ReadStorePdeFile 0
+loadFromStoreDirectly 0
 
 Pedinputfile1 ../Pedestals/PEDS_ACDC_board0.txt
 Pedinputfile2 ../Pedestals/PEDS_ACDC_board1.txt


### PR DESCRIPTION
Add LAPPD beamgate stop tick in 40 MHz clock information to tree Fixed a bug in LAPPDLoadStore. This bug will cause discrepancy between loading data that all have LAPPD info and data that only part have LAPPD info. It will refresh the ANNIEEvent booststore.

 Changes to be committed:
	modified:   DataModel/LAPPDPulse.h
	modified:   UserTools/ANNIEEventTreeMaker/ANNIEEventTreeMaker.cpp
	modified:   UserTools/ANNIEEventTreeMaker/ANNIEEventTreeMaker.h
	modified:   UserTools/LAPPDLoadStore/LAPPDLoadStore.cpp
	modified:   UserTools/LAPPDLoadStore/LAPPDLoadStore.h
	modified:   UserTools/LAPPDStoreReorder/LAPPDStoreReorder.cpp
	modified:   UserTools/LAPPDThresReco/LAPPDThresReco.cpp
	modified:   UserTools/LoadANNIEEvent/LoadANNIEEvent.cpp
	modified:   configfiles/BeamClusterAnalysis/ToolsConfig
	modified:   configfiles/LAPPDProcessedAna/ConfigStoreReadIn
	modified:   configfiles/LAPPDProcessedAna/Configs